### PR TITLE
New Feature: import a path list to a units/includes (-Fu/-Fi) from text-file

### DIFF
--- a/ide/lazarusidestrconsts.pas
+++ b/ide/lazarusidestrconsts.pas
@@ -3412,6 +3412,7 @@ resourcestring
   lisPathEditBrowse = 'Browse';
   lisPathEditPathTemplates = 'Path templates';
   lisPathEditDeleteInvalidPaths = 'Delete Invalid Paths';
+  lisPathEditImportPaths = 'Import Paths';  
   
   // new dialog
   lisNewDlgNoItemSelected = 'No item selected';

--- a/ide/patheditordlg.lfm
+++ b/ide/patheditordlg.lfm
@@ -175,6 +175,25 @@ object PathEditorDialog: TPathEditorDialog
       OnChange = DirectoryEditChange
     end
   end
+  object ImportPathsButton: TBitBtn
+    AnchorSideLeft.Control = DeleteInvalidPathsButton
+    AnchorSideLeft.Side = asrBottom
+    AnchorSideBottom.Control = PathGroupBox
+    AnchorSideBottom.Side = asrBottom
+    Left = 471
+    Height = 25
+    Top = 172
+    Width = 127
+    Anchors = [akLeft, akBottom]
+    AutoSize = True
+    BorderSpacing.Around = 6
+    Caption = 'ImportPathsButton'
+    Enabled = False
+    OnClick = ImportPathsButtonClick
+    ParentShowHint = False
+    ShowHint = True
+    TabOrder = 8
+  end
   object TemplateGroupBox: TGroupBox
     AnchorSideTop.Side = asrBottom
     Left = 6
@@ -254,5 +273,9 @@ object PathEditorDialog: TPathEditorDialog
     Options = [ofFileMustExist, ofEnableSizing, ofViewDetail]
     left = 504
     top = 32
+  end
+  object OpenDialogPathsImport: TOpenDialog
+    left = 408
+    top = 63
   end
 end

--- a/ide/patheditordlg.pas
+++ b/ide/patheditordlg.pas
@@ -32,6 +32,8 @@ type
   TPathEditorDialog = class(TForm)
     AddTemplateButton: TBitBtn;
     ButtonPanel1: TButtonPanel;
+    ImportPathsButton: TBitBtn;
+    OpenDialogPathsImport: TOpenDialog;
     ReplaceButton: TBitBtn;
     AddButton: TBitBtn;
     DeleteInvalidPathsButton: TBitBtn;
@@ -54,6 +56,7 @@ type
     procedure FormCreate(Sender: TObject);
     procedure FormResize(Sender: TObject);
     procedure FormShow(Sender: TObject);
+    procedure ImportPathsButtonClick(Sender: TObject);    
     procedure MoveDownButtonClick(Sender: TObject);
     procedure MoveUpButtonClick(Sender: TObject);
     procedure PathListBoxDrawItem(Control: TWinControl; Index: Integer;
@@ -259,6 +262,7 @@ begin
   DeleteButton.Hint:=lisPathEditorDeleteHint;
   DeleteInvalidPathsButton.Caption:=lisPathEditDeleteInvalidPaths;
   DeleteInvalidPathsButton.Hint:=lisPathEditorDeleteInvalidHint;
+  ImportPathsButton.Caption:=lisPathEditImportPaths;  
 
   TemplateGroupBox.Caption:=lisPathEditPathTemplates;
   AddTemplateButton.Caption:=lisCodeTemplAdd;
@@ -301,6 +305,48 @@ begin
     UpdateButtons;
   end;
 end;
+
+
+procedure TPathEditorDialog.ImportPathsButtonClick(Sender: TObject);
+var paths:TStringList;
+    y:integer;
+    c:integer;
+    RelPath:string;
+begin
+  if not OpenDialogPathsImport.Execute then exit;
+
+  paths:=TStringList.Create();
+
+  try
+    paths.LoadFromFile(OpenDialogPathsImport.FileName);
+
+    with PathListBox do
+    begin
+      y:=ItemIndex+1;
+
+      if y=0 then
+      begin
+        y:=Count;
+      end;
+
+      for c:=0 to paths.Count-1 do
+      begin
+        if Trim(paths[c])<>'' then
+        begin
+          RelPath:=BaseRelative(paths[c]);
+          Items.InsertObject(y, RelPath, PathMayExist(paths[c]));
+          ItemIndex:=y;
+        end;
+      end;
+
+      UpdateButtons;
+    end;
+
+  finally
+    FreeAndNil(paths);
+  end;
+end;
+
 
 procedure TPathEditorDialog.MoveUpButtonClick(Sender: TObject);
 var
@@ -454,6 +500,7 @@ begin
   i := PathListBox.ItemIndex;
   MoveUpButton.Enabled := i > 0;
   MoveDownButton.Enabled := (i > -1) and (i < PathListBox.Count-1);
+  ImportPathsButton.Enabled:=true;
 end;
 
 procedure TPathEditorDialog.SetBaseDirectory(const AValue: string);


### PR DESCRIPTION
Added a Button "Import Paths" to PathEditorDialog
Clicking on it, shows an OpenFileDialog to select a text-file to Import.
Importing is processed by TStringList.LoadFromFile();

The patch is usable on 1.2 and 1.3 Lazarus.

http://bugs.freepascal.org/view.php?id=25903