### PR TITLE
Catch wrong encoded UTF8 Strings in Lazreport

### DIFF
--- a/components/lazreport/source/lr_utils.pas
+++ b/components/lazreport/source/lr_utils.pas
@@ -930,7 +930,14 @@ begin
     b := UTF8CharacterStrictLength(@S[i]);
     inc(i,b);
     inc(Result);
-    Desc[Result] := Char(b);
+    if Result<length(Desc) then
+      Desc[Result] := Char(b)
+    else //abort on invalid UTF8 String
+      begin
+        s := '';
+        Result := 0;
+        exit;
+      end;
   end;
   Setlength(Desc, Result);
 end;


### PR DESCRIPTION
This is an Quick & Dirty fix to catch wrong encoded UTF8 Strings in Lazreport. Otherwise the Stribng is able to crash Lazreport completely