### PR TITLE
Fixed build_debug_apk.bat

### DIFF
--- a/examples/androidlcl/android/build_debug_apk.bat
+++ b/examples/androidlcl/android/build_debug_apk.bat
@@ -30,21 +30,24 @@ call aapt p -v -f -M AndroidManifest.xml -F bin\%APP_NAME%.ap_ -I %APK_SDK_PLATF
 REM Java compiler
 call javac -verbose -encoding UTF8 -classpath %APK_SDK_PLATFORM%\android.jar -d bin\classes src\com\pascal\lcltest\LCLActivity.java
 
-REM DX to convert the java bytecode to dalvik bytecode
-call dx --dex --verbose --output=%APK_PROJECT_PATH%\bin\classes.dex %APK_PROJECT_PATH%\bin\classes
+REM Convert the java bytecode to dalvik bytecode
+call java -Djava.ext.dirs=%ANDROID_HOME%\platform-tools\lib\ -jar %ANDROID_HOME%\platform-tools\lib\dx.jar --dex --verbose --output=%APK_PROJECT_PATH%\bin\classes.dex %APK_PROJECT_PATH%\bin\classes
 
 REM It seams that dx calls echo off
 @echo on
 REM Now build the unsigned APK
 del %APK_PROJECT_PATH%\bin\%APP_NAME%-unsigned.apk
-call apkbuilder %APK_PROJECT_PATH%\bin\%APP_NAME%-unsigned.apk -v -u -z %APK_PROJECT_PATH%\bin\%APP_NAME%.ap_ -f %APK_PROJECT_PATH%\bin\classes.dex
+call java -classpath %ANDROID_HOME%\tools\lib\sdklib.jar com.android.sdklib.build.ApkBuilderMain %APK_PROJECT_PATH%\bin\%APP_NAME%-unsigned.apk -v -u -z %APK_PROJECT_PATH%\bin\%APP_NAME%.ap_ -f %APK_PROJECT_PATH%\bin\classes.dex
 
 REM Generating on the fly a debug key
 rem keytool -genkey -v -keystore bin\LCLDebugKey.keystore -alias LCLDebugKey -keyalg RSA -validity 10000 -dname NAME -storepass senhas -keypass senhas
 
 REM Signing the APK with a debug key
 del bin\%APP_NAME%-unaligned.apk
-jarsigner -verbose -keystore bin\LCLDebugKey.keystore -keypass senhas -storepass senhas -signedjar bin\%APP_NAME%-unaligned.apk bin\%APP_NAME%-unsigned.apk LCLDebugKey
+REM JDK1.6,Please use this command
+jarsigner -verbose -keystore bin\LCLDebugKey.keystore -keypass 123456 -storepass 123456 -signedjar bin\%APP_NAME%-unaligned.apk bin\%APP_NAME%-unsigned.apk LCLDebugKey
+REM JDK1.7 OR JDK1.8,Please use this command
+REM jarsigner -verbose -sigalg MD5withRSA -digestalg SHA1 -keystore bin\LCLDebugKey.keystore -keypass 123456 -storepass 123456 -signedjar bin\%APP_NAME%-unaligned.apk bin\%APP_NAME%-unsigned.apk LCLDebugKey
 
 REM Align the final APK package
 zipalign -v 4 bin\%APP_NAME%-unaligned.apk bin\%APP_NAME%.apk


### PR DESCRIPTION
In new Android SDK, dx.bat and apkbuild.bat is removed, and this old build_debug_apk is not support JDK1.7 or JDK 1.8 Signing APK ,so this patch is fixed this problem.